### PR TITLE
#11

### DIFF
--- a/src/main/java/com/mitmws/httpserver/HttpServerClientHandlerThread.java
+++ b/src/main/java/com/mitmws/httpserver/HttpServerClientHandlerThread.java
@@ -200,7 +200,6 @@ public class HttpServerClientHandlerThread extends Thread {
                         HttpConversation.writeHttpMessage(clientSocket,httpResponse,HttpMessagePart.ALL, HttpMessageFormat.DIRECT, applicationConfig);
                     }
                     else {
-                        System.out.println(String.format("Getting handler script for %s", path));
                         Script handlerScript = routes.get(path);
                         if (handlerScript != null) {
                             httpResponse = buildScriptedHttpMessage(handlerScript, httpRequest);


### PR DESCRIPTION
- Removed extra calls to testLog which updates the table in the bottom right corner
- Test entries are 1 log per test step/payload even in cases of error
- In cases of error, payload is shown